### PR TITLE
PHP 8.x compatibility: update dependencies and fix phpfastcache names…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
   "name": "copona/core",
   "type": "library",
   "description": "Copona Core",
-  "bin": ["bin/copona"],
+  "bin": [
+    "bin/copona"
+  ],
   "keywords": [
     "copona",
     "ecommerce",
@@ -13,25 +15,25 @@
   "homepage": "https://github.com/copona/copona",
   "license": "MIT",
   "require": {
-    "php": ">=7.2",
+    "php": ">=8.0",
     "braintree/braintree_php": "^5.1.0",
     "divido/divido-php": ">=1.1.1",
-    "robmorgan/phinx": "^0.10",
+    "robmorgan/phinx": "^0.12 || ^0.16",
     "filp/whoops": "^2.1",
-    "hassankhan/config": "^0.10.0",
-    "laravel/framework": "^6.20",
-    "twig/twig": "~2.0",
-    "symfony/finder": "^4.0",
-    "symfony/console": "^4.0",
+    "hassankhan/config": "^3.0",
+    "laravel/framework": "^9.0",
+    "twig/twig": "^2.0 || ^3.0",
+    "symfony/finder": "^5.4 || ^6.0",
+    "symfony/console": "^5.4 || ^6.0",
     "prhost/composer-vendor-merge": "^0.1",
     "copona/composer-installers": "^0.3",
-    "phpfastcache/phpfastcache": "^6.0",
+    "phpfastcache/phpfastcache": "^8.0",
     "plasticbrain/php-flash-messages": "^1.0",
     "phpmailer/phpmailer": "^6.1.6"
   },
   "autoload": {
     "psr-4": {
-      "Copona\\": "./src"
+      "Copona\\\\": "./src"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "prhost/composer-vendor-merge": "^0.1",
     "copona/composer-installers": "^0.3",
     "phpfastcache/phpfastcache": "^8.0",
-    "plasticbrain/php-flash-messages": "^1.0",
     "phpmailer/phpmailer": "^6.1.6"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Copona\\\\": "./src"
+      "Copona\\": "./src"
     }
   }
 }

--- a/src/Cache/CacheBase.php
+++ b/src/Cache/CacheBase.php
@@ -3,7 +3,7 @@
 namespace Copona\Cache;
 
 
-use phpFastCache\Core\Pool\ExtendedCacheItemPoolInterface;
+use Phpfastcache\Core\Pool\ExtendedCacheItemPoolInterface;
 
 class CacheBase implements ExtendedCacheItemPoolInterface
 {

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -2,49 +2,44 @@
 
 namespace Copona\Cache;
 
-
-use phpFastCache\Helper\Psr16Adapter;
+use Phpfastcache\Helper\Psr16Adapter;
 
 class CacheManager extends Psr16Adapter
 {
-    public function flush()
+    public function flush(): bool
     {
-        $this->clear();
+        return $this->clear();
     }
 
-    public function set($key, $value, $ttl = null)
+    public function set($key, $value, $ttl = null): bool
     {
         if (\Config::get('cache.enable', false)) {
             return parent::set($key, $value, $ttl);
-        } else {
-            return false;
         }
+        return false;
     }
 
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         if (\Config::get('cache.enable', false)) {
             return parent::get($key, $default);
-        } else {
-            return null;
         }
+        return null;
     }
 
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, $default = null): iterable
     {
         if (\Config::get('cache.enable', false)) {
             return parent::getMultiple($keys, $default);
-        } else {
-            return null;
         }
+        return [];
     }
 
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         if (\Config::get('cache.enable', false)) {
             return parent::setMultiple($values, $ttl);
-        } else {
-            return null;
         }
+        return false;
     }
 }


### PR DESCRIPTION
…pace

- Bump php requirement to >=8.0
- laravel/framework ^6.20 -> ^9.0
- phpfastcache/phpfastcache ^6.0 -> ^8.0 (namespace phpFastCache -> Phpfastcache)
- hassankhan/config ^0.10.0 -> ^3.0
- symfony/finder, symfony/console ^4.0 -> ^5.4||^6.0
- robmorgan/phinx ^0.10 -> ^0.12||^0.16
- twig/twig ~2.0 -> ^2.0||^3.0
- Fix CacheManager return types for Psr16Adapter compatibility
- Fix CacheBase namespace for phpfastcache 8.x