### PR TITLE
Pin twig/twig to ^3.26, fixing 8 Dependabot security alerts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "filp/whoops": "^2.1",
     "hassankhan/config": "^3.0",
     "laravel/framework": "^10.48",
-    "twig/twig": "^2.0 || ^3.0",
+    "twig/twig": "^3.26",
     "symfony/finder": "^6.0 || ^7.0",
     "symfony/console": "^6.0 || ^7.0",
     "prhost/composer-vendor-merge": "^0.1",


### PR DESCRIPTION
## Summary

Pins `twig/twig` from `^2.0 || ^3.0` to `^3.26`, fixing all 8 open Twig Dependabot alerts:

| Severity | CVE/Advisory | Issue |
|----------|-------------|-------|
| Critical | CVE-2026-46633 | PHP code injection via `{% use %}` template name |
| High | GHSA | Multiple `__toString()` sandbox bypasses |
| Medium | GHSA | `{% sandbox %}{% include %}` skips `checkSecurity()` |
| Medium | GHSA | Possible sandbox bypass |
| Low | GHSA | Sandbox property allowlist bypass via `column` filter |
| Low | GHSA | `spaceless` filter marks output as safe |
| Low | GHSA | Unguarded `__isset()` calls in sandbox |
| Low | GHSA | Unguarded `__toString()` calls in sandbox |

The `Twig.php` adapter in `copona/copona` was already updated to use 3.x class names (`Twig\Environment`, `Twig\Loader\FilesystemLoader`, `Twig\Error\SyntaxError`) in a previous commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)