### PR TITLE
Fix InstallCommand::execute() return type for Symfony 5+

### DIFF
--- a/src/Cli/Commands/InstallCommand.php
+++ b/src/Cli/Commands/InstallCommand.php
@@ -41,9 +41,9 @@ class InstallCommand extends Command
      *
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return bool|int|null
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = CommandHelper::prepareIO($input, $output);
 
@@ -57,17 +57,20 @@ class InstallCommand extends Command
             $questionReinstall = new ConfirmationQuestion("<error>Do you want to reinstall again? All database will be erased. (yes/no) [no]</error>", false);
             $answerReinstall = $helper->ask($input, $output, $questionReinstall);
 
-            if ($answerReinstall) {
-                $this->reinstall = true;
-                CommandHelper::clear($io, $output);
-                $this->checkRequirementsStep($io, $output, $input);
-                $output->writeln('<info>Copona successfully installed</info>');
+            if (!$answerReinstall) {
+                return Command::SUCCESS;
             }
 
+            $this->reinstall = true;
+            CommandHelper::clear($io, $output);
+            $this->checkRequirementsStep($io, $output, $input);
+            $output->writeln('<info>Copona successfully installed</info>');
         } else {
             $this->checkRequirementsStep($io, $output, $input);
             $output->writeln('<info>Copona successfully installed</info>');
         }
+
+        return Command::SUCCESS;
     }
 
     protected function checkRequirementsStep(SymfonyStyle $io, OutputInterface $output, InputInterface $input)


### PR DESCRIPTION
## Summary

- Adds `int` return type to `execute()` to satisfy Symfony 5+ requirement
- Adds explicit `Command::SUCCESS` return in both the normal and reinstall paths
- Fixes the early-exit when user declines reinstall (previously returned nothing, now returns `Command::SUCCESS` immediately)

## Why it broke
Laravel 10 pulled in Symfony Console 6.x, which strictly enforces that `execute()` returns `int`. The old code had no return statement, causing a `TypeError` crash whenever the install command ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)